### PR TITLE
Make "autoreconf -i" to work on fedora 21.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_PREREQ([2.65])
 AC_CONFIG_SRCDIR([pdfdoc.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
+LT_INIT()
 
 KPSE_COMMON([libtexpdf])
 


### PR DESCRIPTION
I followed your FOSDEM presentation this week-end and would like to try SILE to typeset some songbook.
To do this, I'll first try to create some reusable fedora packages. 

So, here is a first PR to get autoreconf work on my fedora 21.
Note that following fedora packaging guidelines, projects should not include external libraries sources, so that's why I'm trying first to create a package for libtexpdf before doing the sile one.
