### PR TITLE
Port to MSVC with CMake script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ libtexpdf_la-type1c.lo
 libtexpdf_la-unicode.lo
 libtool
 stamp-h1
+build/ 
+.vscode/ 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,106 @@
+cmake_minimum_required(VERSION 3.0)
+
+function(get_version_from_ac var file_name)
+    file(STRINGS "${file_name}" ac_init_string REGEX "^AC_INIT")
+    string(REGEX REPLACE "^AC_INIT\\(\\[.*\\], \\[([0-9]+)\\], \\[.*\\]\\)" "\\1" ac_version ${ac_init_string})
+    set(${var} ${ac_version} PARENT_SCOPE)
+endfunction()
+
+get_version_from_ac(LIBTEXPDF_VERSION configure.ac)
+
+include(CheckIncludeFile)
+include(CheckFunctionExists)
+include(CheckSymbolExists)
+include(CheckTypeSize)
+include(CheckStructHasMember)
+include(CheckLibraryExists)
+
+project(libtexpdf VERSION ${LIBTEXPDF_VERSION} LANGUAGES C)
+
+if (WIN32)
+	include(ExternalProject)
+
+	set(TMP_INSTALL_DIR "${CMAKE_BINARY_DIR}/tmp_install")
+
+	ExternalProject_Add(zlib
+		GIT_REPOSITORY https://github.com/madler/zlib
+		GIT_TAG v1.2.11
+		CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>"
+		INSTALL_DIR "${TMP_INSTALL_DIR}")
+
+	# Never use dynamic version of zlib. workaround by replace zlib with zlibstatic
+	ExternalProject_Add_Step(zlib replace_lib
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${TMP_INSTALL_DIR}/lib/zlibstatic.lib" "${TMP_INSTALL_DIR}/lib/zlib.lib"
+		DEPENDEES install)
+
+	ExternalProject_Add(libpng
+		DEPENDS zlib
+		GIT_REPOSITORY https://github.com/glennrp/libpng
+		GIT_TAG v1.6.36
+		CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>" "-DZLIB_ROOT=${TMP_INSTALL_DIR}"
+		INSTALL_DIR "${TMP_INSTALL_DIR}")
+
+	set(HAVE_ZLIB 1)
+	set(HAVE_ZLIB_COMPRESS2 1)
+	set(HAVE_LIBPNG 1)
+
+else()
+	find_package(PNG)
+	find_package(ZLIB)
+
+	if (ZLIB_FOUND)
+		set(HAVE_ZLIB 1)
+		set(HAVE_ZLIB_COMPRESS2 1)
+	endif()
+	if (PNG_FOUND)
+		set(HAVE_LIBPNG 1)
+	endif()
+endif()
+
+# Checks for header files.
+check_include_file(inttypes.h HAVE_INTTYPES_H)
+check_include_file(memory.h HAVE_MEMORY_H)
+check_include_file(stdbool.h HAVE_STDBOOL_H)
+check_include_file(stdint.h HAVE_STDINT_H)
+check_include_file(stdlib.h HAVE_STDLIB_H)
+check_include_file(string.h HAVE_STRING_H)
+check_include_file(sys/stat.h HAVE_SYS_STAT_H)
+check_include_file(sys/types.h HAVE_SYS_TYPES_H)
+check_include_file(sys/wait.h HAVE_SYS_WAIT_H)
+check_include_file(sys/stdbool.h HAVE_SYS_STDBOOL_H)
+
+# Checks for library functions.
+check_function_exists(getenv HAVE_GETENV)
+check_function_exists(mkstemp HAVE_MKSTEMP)
+
+# Checks for typedefs, structures, and compiler characteristics.
+check_symbol_exists(timezone time.h HAVE_TIMEZONE)
+check_struct_has_member("struct tm" tm_gmtoff time.h HAVE_TM_GMTOFF)
+
+check_type_size(long SIZEOF_LONG)
+
+set(PACKAGE_NAME "\"${PROJECT_NAME}\"")
+set(PACKAGE_VERSION "\"${LIBTEXPDF_VERSION}\"")
+
+configure_file(config.h.cmake config.h)
+
+file(GLOB SRC_FILES *.c)
+file(GLOB HDR_FILES *.h)
+set(TEST_SRC library-poc.c)
+list(REMOVE_ITEM SRC_FILES ${TEST_SRC})
+
+add_library(libtexpdf STATIC ${SRC_FILES} ${HDR_FILES})
+add_dependencies(libtexpdf zlib libpng)
+target_compile_definitions(libtexpdf PUBLIC HAVE_CONFIG_H=1 CDECL=)
+target_compile_definitions(libtexpdf PRIVATE BUILDING_LIBTEXPDF=1)
+if (WIN32)
+	target_include_directories(libtexpdf PUBLIC "${CMAKE_CURRENT_BINARY_DIR}" "${TMP_INSTALL_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/win32")
+	target_link_directories(libtexpdf PUBLIC "${TMP_INSTALL_DIR}/lib")
+	target_link_libraries(libtexpdf PUBLIC optimized zlibstatic debug zlibstaticd)
+	target_link_libraries(libtexpdf PUBLIC optimized libpng16_static debug libpng16_staticd)
+else()
+	target_link_libraries(libtexpdf PUBLIC ZLIB::ZLIB PNG::PNG)
+endif()
+
+add_executable(libtexpdf_test ${TEST_SRC})
+target_link_libraries(libtexpdf_test PUBLIC libtexpdf)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,0 +1,56 @@
+/* Define to 1 if you have the `getenv' function. */
+#cmakedefine HAVE_GETENV @HAVE_GETENV@
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H @HAVE_INTTYPES_H@
+
+/* Define if you have libpng and its headers. */
+#cmakedefine HAVE_LIBPNG @HAVE_LIBPNG@
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H @HAVE_MEMORY_H@
+
+/* Define to 1 if you have the `mkstemp' function. */
+#cmakedefine HAVE_MKSTEMP @HAVE_MKSTEMP@
+
+/* Define to 1 if you have the <stdbool.h> header file. */
+#cmakedefine HAVE_STDBOOL_H @HAVE_STDBOOL_H@
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H @HAVE_STDINT_H@
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H @HAVE_STDLIB_H@
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H @HAVE_STRING_H@
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H @HAVE_SYS_STAT_H@
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H @HAVE_SYS_TYPES_H@
+
+/* Define to 1 if you have the <sys/wait.h> header file. */
+#cmakedefine HAVE_SYS_WAIT_H @HAVE_SYS_WAIT_H@
+
+/* Define if <time.h> has timezone as an external variable. */
+#cmakedefine HAVE_TIMEZONE @HAVE_TIMEZONE@
+
+/* Define if struct tm has tm_gmtoff as a member. */
+#cmakedefine HAVE_TM_GMTOFF @HAVE_TM_GMTOFF@
+
+/* Define if you have zlib and its headers. */
+#cmakedefine HAVE_ZLIB @HAVE_ZLIB@
+
+/* Define if your zlib has the compress2 function. */
+#cmakedefine HAVE_ZLIB_COMPRESS2 @HAVE_ZLIB_COMPRESS2@
+
+/* Define to the full name of this package. */
+#cmakedefine PACKAGE_NAME @PACKAGE_NAME@
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_VERSION @PACKAGE_VERSION@
+
+/* The size of `long', as computed by sizeof. */
+#cmakedefine SIZEOF_LONG @SIZEOF_LONG@

--- a/error.h
+++ b/error.h
@@ -58,9 +58,4 @@ extern void WARN  (const char *fmt, ...);
 
 #define ASSERT(e) assert(e)
 
-#if defined(WIN32) && !defined(__MINGW32__)
-#undef vfprintf
-#define vfprintf win32_vfprintf
-#endif
-
 #endif /* _ERROR_H_ */

--- a/library-poc.c
+++ b/library-poc.c
@@ -8,7 +8,7 @@ gcc -g -o library-poc  -I.. ./.libs/libtexpdf.a library-poc.c -lpng -lz `pkg-con
 */
 
 #include <stdint.h>
-#include "libtexpdf/libtexpdf.h"
+#include "libtexpdf.h"
 
 int load_font (char* filename) {
   char fontmap_key[1024];

--- a/libtexpdf.h
+++ b/libtexpdf.h
@@ -49,6 +49,10 @@ extern int compat_mode;
 #define fseeko fseeko64
 #endif
 
+#if defined(__APPLE__)
+#define off64_t off_t
+#endif
+
 #include "agl.h"
 #include "bmpimage.h"
 #include "cff.h"

--- a/libtexpdf.h
+++ b/libtexpdf.h
@@ -3,7 +3,7 @@
 #define XETEX 1 /* We are all xetex now */
 
 #ifdef BUILDING_LIBTEXPDF
-#include <libtexpdf/config.h>
+#include <config.h>
 #endif
 
 #ifdef HAVE_STRING_H
@@ -38,6 +38,16 @@ extern int compat_mode;
 #ifndef FOPEN_WBIN_MODE
 #define FOPEN_WBIN_MODE "wb"
 #endif /* not FOPEN_WBIN_MODE */
+
+#if defined(WIN32) && !defined(__MINGW32__)
+#define off64_t int64_t
+#define ftello _ftelli64
+#define fseeko _fseeki64
+#include "win32/win32.h"
+#elif defined(__MINGW32__)
+#define ftello ftello64
+#define fseeko fseeko64
+#endif
 
 #include "agl.h"
 #include "bmpimage.h"
@@ -100,10 +110,5 @@ extern int compat_mode;
 #include "type1.h"
 #include "type1c.h"
 #include "unicode.h"
-#ifdef __MINGW32__
-#define off_t off64_t
-#define ftello ftello64
-#define fseeko fseeko64
-#endif
 
 #endif

--- a/mfileio.c
+++ b/mfileio.c
@@ -42,11 +42,7 @@ FILE *mfopen(const char *name, const char *mode, const char *function, int line)
 {
   FILE *tmp;
   io_debug_init();
-#if defined(WIN32)
-  tmp = fsyscp_fopen (name, mode);
-#else
   tmp = fopen (name, mode);
-#endif
   event += 1;
   fprintf(iodebug_file, "%p %07ld [fopen] %s:%d\n", tmp, event,
 	  function, line);
@@ -108,9 +104,9 @@ long file_size (FILE *file)
   return (size);
 }
 
-off_t xfile_size (FILE *file, const char *name)
+off64_t xfile_size (FILE *file, const char *name)
 {
-  off_t size;
+  off64_t size;
   xseek_end (file, name);
   size = xtell_position (file, name);
   rewind (file);

--- a/mfileio.h
+++ b/mfileio.h
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include "numbers.h"
+#include "libtexpdf.h"
 
 #ifdef IODEBUG
 FILE *mfopen (const char *name, const char *mode,
@@ -35,11 +36,7 @@ int mfclose (FILE *file, const char *function, int line);
 #define MFCLOSE(file) \
    mfclose((file),__FUNCTION__,__LINE__)
 #else
-#if defined(WIN32) && !defined(__MINGW32__)
-#define MFOPEN(name,mode) fsyscp_fopen((name),(mode))
-#else
 #define MFOPEN(name,mode) fopen((name),(mode))
-#endif
 #define MFCLOSE(file) fclose(file)
 #endif
 
@@ -52,12 +49,12 @@ extern long tell_position (FILE *file);
 
 extern long file_size (FILE *file);
 
-#define xseek_absolute(file, pos, name) fseeko (file, (off_t)(pos), SEEK_SET)
-#define xseek_relative(file, pos, name) fseeko (file, (off_t)(pos), SEEK_CUR)
-#define xseek_end(file, name) fseeko (file, (off_t)0, SEEK_END)
+#define xseek_absolute(file, pos, name) fseeko (file, (off64_t)(pos), SEEK_SET)
+#define xseek_relative(file, pos, name) fseeko (file, (off64_t)(pos), SEEK_CUR)
+#define xseek_end(file, name) fseeko (file, (off64_t)0, SEEK_END)
 #define xtell_position(file, name) ftello (file)
 
-extern off_t xfile_size (FILE *file, const char *name);
+extern off64_t xfile_size (FILE *file, const char *name);
 
 extern char *mfgets (char *buffer, int length, FILE *file);
 

--- a/numbers.h
+++ b/numbers.h
@@ -23,6 +23,10 @@
 #ifndef _NUMBERS_H_
 #define _NUMBERS_H_
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdio.h>
 #include <math.h>
 #ifdef HAVE_INTTYPES_H

--- a/pdfobj.c
+++ b/pdfobj.c
@@ -22,6 +22,10 @@
 
 #include "libtexpdf.h"
 
+#ifdef WIN32
+#include <fcntl.h>
+#endif
+
 #ifdef HAVE_ZLIB
 #include <zlib.h>
 #endif /* HAVE_ZLIB */
@@ -2152,8 +2156,8 @@ pdf_concat_stream (pdf_obj *dst, pdf_obj *src)
       }
     } else
       ERROR("Broken PDF file?");
-#endif /* HAVE_ZLIB */
   }
+#endif /* HAVE_ZLIB */
 
   return error;
 }

--- a/pngimage.c
+++ b/pngimage.c
@@ -22,7 +22,7 @@
 #define XETEX 1 /* We are all xetex now */
 
 #ifdef BUILDING_LIBTEXPDF
-#include <libtexpdf/config.h>
+#include <config.h>
 #endif
 
 /*

--- a/tfm.c
+++ b/tfm.c
@@ -343,7 +343,7 @@ fread_uquads (uint32_t *quads, int32_t nmemb, FILE *fp)
  * TFM and JFM
  */
 static void
-tfm_check_size (struct tfm_font *tfm, off_t tfm_file_size)
+tfm_check_size (struct tfm_font *tfm, off64_t tfm_file_size)
 {
   uint32_t expected_size = 6;
 
@@ -390,7 +390,7 @@ tfm_check_size (struct tfm_font *tfm, off_t tfm_file_size)
 }
 
 static void
-texpdf_tfm_get_sizes (FILE *tfm_file, off_t tfm_file_size, struct tfm_font *tfm)
+texpdf_tfm_get_sizes (FILE *tfm_file, off64_t tfm_file_size, struct tfm_font *tfm)
 {
 #ifndef WITHOUT_ASCII_PTEX
   {
@@ -569,7 +569,7 @@ tfm_unpack_header (struct font_metric *fm, struct tfm_font *tfm)
 #ifndef WITHOUT_OMEGA
 
 static void
-ofm_check_size_one (struct tfm_font *tfm, off_t ofm_file_size)
+ofm_check_size_one (struct tfm_font *tfm, off64_t ofm_file_size)
 {
   uint32_t ofm_size = 14;
 
@@ -590,7 +590,7 @@ ofm_check_size_one (struct tfm_font *tfm, off_t ofm_file_size)
 }
 
 static void
-ofm_get_sizes (FILE *ofm_file, off_t ofm_file_size, struct tfm_font *tfm)
+ofm_get_sizes (FILE *ofm_file, off64_t ofm_file_size, struct tfm_font *tfm)
 {
   tfm->level = get_signed_quad(ofm_file);
 
@@ -619,7 +619,7 @@ ofm_get_sizes (FILE *ofm_file, off_t ofm_file_size, struct tfm_font *tfm)
     tfm->nco = get_positive_quad(ofm_file, "OFM", "nco");
     tfm->ncw = get_positive_quad(ofm_file, "OFM", "nco");
     tfm->npc = get_positive_quad(ofm_file, "OFM", "npc");
-    xseek_absolute(ofm_file, 4*(off_t)(tfm->nco - tfm->wlenheader), "OFM");
+    xseek_absolute(ofm_file, 4*(off64_t)(tfm->nco - tfm->wlenheader), "OFM");
   } else {
     ERROR("Can't handle OFM files with level > 1");
   }
@@ -716,7 +716,7 @@ ofm_unpack_arrays (struct font_metric *fm,
 }
 
 static void
-read_ofm (struct font_metric *fm, FILE *ofm_file, off_t ofm_file_size)
+read_ofm (struct font_metric *fm, FILE *ofm_file, off64_t ofm_file_size)
 {
   struct tfm_font tfm;
 
@@ -762,7 +762,7 @@ read_ofm (struct font_metric *fm, FILE *ofm_file, off_t ofm_file_size)
 #endif /* !WITHOUT_OMEGA */
 
 static void
-read_tfm (struct font_metric *fm, FILE *tfm_file, off_t tfm_file_size)
+read_tfm (struct font_metric *fm, FILE *tfm_file, off64_t tfm_file_size)
 {
   struct tfm_font tfm;
 
@@ -818,7 +818,7 @@ texpdf_tfm_open (const char *path, const char *tex_name, int must_exist)
 {
   FILE *tfm_file;
   int i, format = TFM_FORMAT;
-  off_t tfm_file_size;
+  off64_t tfm_file_size;
 
   for (i = 0; i < numfms; i++) {
     if (!strcmp(tex_name, fms[i].tex_name))

--- a/win32/dirent.h
+++ b/win32/dirent.h
@@ -1,0 +1,889 @@
+/*
+ * dirent.h - dirent API for Microsoft Visual Studio
+ *
+ * Copyright (C) 2006-2012 Toni Ronkko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * ``Software''), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL TONI RONKKO BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * Version 1.13, Dec 12 2012, Toni Ronkko
+ * Use traditional 8+3 file name if the name cannot be represented in the
+ * default ANSI code page.  Now compiles again with MSVC 6.0.  Thanks to
+ * Konstantin Khomoutov for testing.
+ *
+ * Version 1.12.1, Oct 1 2012, Toni Ronkko
+ * Bug fix: renamed wide-character DIR structure _wDIR to _WDIR (with
+ * capital W) in order to maintain compatibility with MingW.
+ *
+ * Version 1.12, Sep 30 2012, Toni Ronkko
+ * Define PATH_MAX and NAME_MAX.  Added wide-character variants _wDIR, 
+ * _wdirent, _wopendir(), _wreaddir(), _wclosedir() and _wrewinddir().
+ * Thanks to Edgar Buerkle and Jan Nijtmans for ideas and code.
+ *
+ * Do not include windows.h.  This allows dirent.h to be integrated more
+ * easily into programs using winsock.  Thanks to Fernando Azaldegui.
+ *
+ * Version 1.11, Mar 15, 2011, Toni Ronkko
+ * Defined FILE_ATTRIBUTE_DEVICE for MSVC 6.0.
+ *
+ * Version 1.10, Aug 11, 2010, Toni Ronkko
+ * Added d_type and d_namlen fields to dirent structure.  The former is
+ * especially useful for determining whether directory entry represents a
+ * file or a directory.  For more information, see
+ * http://www.delorie.com/gnu/docs/glibc/libc_270.html
+ *
+ * Improved conformance to the standards.  For example, errno is now set
+ * properly on failure and assert() is never used.  Thanks to Peter Brockam
+ * for suggestions.
+ *
+ * Fixed a bug in rewinddir(): when using relative directory names, change
+ * of working directory no longer causes rewinddir() to fail.
+ *
+ * Version 1.9, Dec 15, 2009, John Cunningham
+ * Added rewinddir member function
+ *
+ * Version 1.8, Jan 18, 2008, Toni Ronkko
+ * Using FindFirstFileA and WIN32_FIND_DATAA to avoid converting string
+ * between multi-byte and unicode representations.  This makes the
+ * code simpler and also allows the code to be compiled under MingW.  Thanks
+ * to Azriel Fasten for the suggestion.
+ *
+ * Mar 4, 2007, Toni Ronkko
+ * Bug fix: due to the strncpy_s() function this file only compiled in
+ * Visual Studio 2005.  Using the new string functions only when the
+ * compiler version allows.
+ *
+ * Nov  2, 2006, Toni Ronkko
+ * Major update: removed support for Watcom C, MS-DOS and Turbo C to
+ * simplify the file, updated the code to compile cleanly on Visual
+ * Studio 2005 with both unicode and multi-byte character strings,
+ * removed rewinddir() as it had a bug.
+ *
+ * Aug 20, 2006, Toni Ronkko
+ * Removed all remarks about MSVC 1.0, which is antiqued now.  Simplified
+ * comments by removing SGML tags.
+ *
+ * May 14 2002, Toni Ronkko
+ * Embedded the function definitions directly to the header so that no
+ * source modules need to be included in the Visual Studio project.  Removed
+ * all the dependencies to other projects so that this header file can be
+ * used independently.
+ *
+ * May 28 1998, Toni Ronkko
+ * First version.
+ *****************************************************************************/
+#ifndef DIRENT_H
+#define DIRENT_H
+
+#if !defined(_68K_) && !defined(_MPPC_) && !defined(_X86_) && !defined(_IA64_) && !defined(_AMD64_) && defined(_M_IX86)
+#   define _X86_
+#endif
+#include <stdio.h>
+#include <stdarg.h>
+#include <wtypes.h>
+#include <windef.h>
+#include <winbase.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+/* Indicates that d_type field is available in dirent structure */
+#define _DIRENT_HAVE_D_TYPE
+
+/* Indicates that d_namlen field is available in dirent structure */
+#define _DIRENT_HAVE_D_NAMLEN
+
+/* Entries missing from MSVC 6.0 */
+#if !defined(FILE_ATTRIBUTE_DEVICE)
+#   define FILE_ATTRIBUTE_DEVICE 0x40
+#endif
+
+/* File type and permission flags for stat() */
+#if !defined(S_IFMT)
+#   define S_IFMT   _S_IFMT                     /* File type mask */
+#endif
+#if !defined(S_IFDIR)
+#   define S_IFDIR  _S_IFDIR                    /* Directory */
+#endif
+#if !defined(S_IFCHR)
+#   define S_IFCHR  _S_IFCHR                    /* Character device */
+#endif
+#if !defined(S_IFFIFO)
+#   define S_IFFIFO _S_IFFIFO                   /* Pipe */
+#endif
+#if !defined(S_IFREG)
+#   define S_IFREG  _S_IFREG                    /* Regular file */
+#endif
+#if !defined(S_IREAD)
+#   define S_IREAD  _S_IREAD                    /* Read permission */
+#endif
+#if !defined(S_IWRITE)
+#   define S_IWRITE _S_IWRITE                   /* Write permission */
+#endif
+#if !defined(S_IEXEC)
+#   define S_IEXEC  _S_IEXEC                    /* Execute permission */
+#endif
+#if !defined(S_IFIFO)
+#   define S_IFIFO _S_IFIFO                     /* Pipe */
+#endif
+#if !defined(S_IFBLK)
+#   define S_IFBLK   0                          /* Block device */
+#endif
+#if !defined(S_IFLNK)
+#   define S_IFLNK   0                          /* Link */
+#endif
+#if !defined(S_IFSOCK)
+#   define S_IFSOCK  0                          /* Socket */
+#endif
+
+#if defined(_MSC_VER)
+#   define S_IRUSR  S_IREAD                     /* Read user */
+#   define S_IWUSR  S_IWRITE                    /* Write user */
+#   define S_IXUSR  0                           /* Execute user */
+#   define S_IRGRP  0                           /* Read group */
+#   define S_IWGRP  0                           /* Write group */
+#   define S_IXGRP  0                           /* Execute group */
+#   define S_IROTH  0                           /* Read others */
+#   define S_IWOTH  0                           /* Write others */
+#   define S_IXOTH  0                           /* Execute others */
+#endif
+
+/* Maximum length of file name */
+#if !defined(PATH_MAX)
+#   define PATH_MAX MAX_PATH
+#endif
+#if !defined(FILENAME_MAX)
+#   define FILENAME_MAX MAX_PATH
+#endif
+#if !defined(NAME_MAX)
+#   define NAME_MAX FILENAME_MAX
+#endif
+
+/* File type flags for d_type */
+#define DT_UNKNOWN  0
+#define DT_REG      S_IFREG
+#define DT_DIR      S_IFDIR
+#define DT_FIFO     S_IFIFO
+#define DT_SOCK     S_IFSOCK
+#define DT_CHR      S_IFCHR
+#define DT_BLK      S_IFBLK
+
+/* Macros for converting between st_mode and d_type */
+#define IFTODT(mode) ((mode) & S_IFMT)
+#define DTTOIF(type) (type)
+
+/*
+ * File type macros.  Note that block devices, sockets and links cannot be
+ * distinguished on Windows and the macros S_ISBLK, S_ISSOCK and S_ISLNK are
+ * only defined for compatibility.  These macros should always return false
+ * on Windows.
+ */
+#define	S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#define	S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+#define	S_ISREG(mode)  (((mode) & S_IFMT) == S_IFREG)
+#define	S_ISLNK(mode)  (((mode) & S_IFMT) == S_IFLNK)
+#define	S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#define	S_ISCHR(mode)  (((mode) & S_IFMT) == S_IFCHR)
+#define	S_ISBLK(mode)  (((mode) & S_IFMT) == S_IFBLK)
+
+/* Return the exact length of d_namlen without zero terminator */
+#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
+
+/* Return number of bytes needed to store d_namlen */
+#define _D_ALLOC_NAMLEN(p) (PATH_MAX + 1)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Wide-character version */
+struct _wdirent {
+    long d_ino;                                 /* Always zero */
+    unsigned short d_reclen;                    /* Structure size */
+    size_t d_namlen;                            /* Length of name without \0 */
+    int d_type;                                 /* File type */
+    wchar_t d_name[PATH_MAX + 1];               /* File name */
+};
+typedef struct _wdirent _wdirent;
+
+struct _WDIR {
+    struct _wdirent ent;                        /* Current directory entry */
+    WIN32_FIND_DATAW data;                      /* Private file data */
+    int cached;                                 /* True if data is valid */
+    HANDLE handle;                              /* Win32 search handle */
+    wchar_t *patt;                              /* Initial directory name */
+};
+typedef struct _WDIR _WDIR;
+
+static _WDIR *_wopendir (const wchar_t *dirname);
+static struct _wdirent *_wreaddir (_WDIR *dirp);
+static int _wclosedir (_WDIR *dirp);
+static void _wrewinddir (_WDIR* dirp);
+
+
+/* For compatibility with Symbian */
+#define wdirent _wdirent
+#define WDIR _WDIR
+#define wopendir _wopendir
+#define wreaddir _wreaddir
+#define wclosedir _wclosedir
+#define wrewinddir _wrewinddir
+
+
+/* Multi-byte character versions */
+struct dirent {
+    long d_ino;                                 /* Always zero */
+    unsigned short d_reclen;                    /* Structure size */
+    size_t d_namlen;                            /* Length of name without \0 */
+    int d_type;                                 /* File type */
+    char d_name[PATH_MAX + 1];                  /* File name */
+};
+typedef struct dirent dirent;
+
+struct DIR {
+    struct dirent ent;
+    struct _WDIR *wdirp;
+};
+typedef struct DIR DIR;
+
+static DIR *opendir (const char *dirname);
+static struct dirent *readdir (DIR *dirp);
+static int closedir (DIR *dirp);
+static void rewinddir (DIR* dirp);
+
+
+/* Internal utility functions */
+static WIN32_FIND_DATAW *dirent_first (_WDIR *dirp);
+static WIN32_FIND_DATAW *dirent_next (_WDIR *dirp);
+
+static int dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count);
+
+static int dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes,
+    const wchar_t *wcstr,
+    size_t count);
+
+static void dirent_set_errno (int error);
+
+/*
+ * Open directory stream DIRNAME for read and return a pointer to the
+ * internal working area that is used to retrieve individual directory
+ * entries.
+ */
+static _WDIR*
+_wopendir(
+    const wchar_t *dirname)
+{
+    _WDIR *dirp = NULL;
+    int error;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate new _WDIR structure */
+    dirp = (_WDIR*) malloc (sizeof (struct _WDIR));
+    if (dirp != NULL) {
+        DWORD n;
+
+        /* Reset _WDIR structure */
+        dirp->handle = INVALID_HANDLE_VALUE;
+        dirp->patt = NULL;
+        dirp->cached = 0;
+
+        /* Compute the length of full path plus zero terminator */
+        n = GetFullPathNameW (dirname, 0, NULL, NULL);
+
+        /* Allocate room for absolute directory name and search pattern */
+        dirp->patt = (wchar_t*) malloc (sizeof (wchar_t) * n + 16);
+        if (dirp->patt) {
+
+            /*
+             * Convert relative directory name to an absolute one.  This
+             * allows rewinddir() to function correctly even when current
+             * working directory is changed between opendir() and rewinddir().
+             */
+            n = GetFullPathNameW (dirname, n, dirp->patt, NULL);
+            if (n > 0) {
+                wchar_t *p;
+
+                /* Append search pattern \* to the directory name */
+                p = dirp->patt + n;
+                if (dirp->patt < p) {
+                    switch (p[-1]) {
+                    case '\\':
+                    case '/':
+                    case ':':
+                        /* Directory ends in path separator, e.g. c:\temp\ */
+                        /*NOP*/;
+                        break;
+
+                    default:
+                        /* Directory name doesn't end in path separator */
+                        *p++ = '\\';
+                    }
+                }
+                *p++ = '*';
+                *p = '\0';
+
+                /* Open directory stream and retrieve the first entry */
+                if (dirent_first (dirp)) {
+                    /* Directory stream opened successfully */
+                    error = 0;
+                } else {
+                    /* Cannot retrieve first entry */
+                    error = 1;
+                    dirent_set_errno (ENOENT);
+                }
+
+            } else {
+                /* Cannot retrieve full path name */
+                dirent_set_errno (ENOENT);
+                error = 1;
+            }
+
+        } else {
+            /* Cannot allocate memory for search pattern */
+            error = 1;
+        }
+
+    } else {
+        /* Cannot allocate _WDIR structure */
+        error = 1;
+    }
+
+    /* Clean up in case of error */
+    if (error  &&  dirp) {
+        _wclosedir (dirp);
+        dirp = NULL;
+    }
+
+    return dirp;
+}
+
+/*
+ * Read next directory entry.  The directory entry is returned in dirent
+ * structure in the d_name field.  Individual directory entries returned by
+ * this function include regular files, sub-directories, pseudo-directories
+ * "." and ".." as well as volume labels, hidden files and system files.
+ */
+static struct _wdirent*
+_wreaddir(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *datap;
+    struct _wdirent *entp;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp);
+    if (datap) {
+        size_t n;
+        DWORD attr;
+        
+        /* Pointer to directory entry to return */
+        entp = &dirp->ent;
+
+        /* 
+         * Copy file name as wide-character string.  If the file name is too
+         * long to fit in to the destination buffer, then truncate file name
+         * to PATH_MAX characters and zero-terminate the buffer.
+         */
+        n = 0;
+        while (n < PATH_MAX  &&  datap->cFileName[n] != 0) {
+            entp->d_name[n] = datap->cFileName[n];
+            n++;
+        }
+        dirp->ent.d_name[n] = 0;
+
+        /* Length of file name excluding zero terminator */
+        entp->d_namlen = n;
+
+        /* File type */
+        attr = datap->dwFileAttributes;
+        if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+            entp->d_type = DT_CHR;
+        } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            entp->d_type = DT_DIR;
+        } else {
+            entp->d_type = DT_REG;
+        }
+
+        /* Reset dummy fields */
+        entp->d_ino = 0;
+        entp->d_reclen = sizeof (struct _wdirent);
+
+    } else {
+
+        /* Last directory entry read */
+        entp = NULL;
+
+    }
+
+    return entp;
+}
+
+/*
+ * Close directory stream opened by opendir() function.  This invalidates the
+ * DIR structure as well as any directory entry read previously by
+ * _wreaddir().
+ */
+static int
+_wclosedir(
+    _WDIR *dirp)
+{
+    int ok;
+    if (dirp) {
+
+        /* Release search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+            dirp->handle = INVALID_HANDLE_VALUE;
+        }
+
+        /* Release search pattern */
+        if (dirp->patt) {
+            free (dirp->patt);
+            dirp->patt = NULL;
+        }
+
+        /* Release directory structure */
+        free (dirp);
+        ok = /*success*/0;
+
+    } else {
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream such that _wreaddir() returns the very first
+ * file name again.
+ */
+static void
+_wrewinddir(
+    _WDIR* dirp)
+{
+    if (dirp) {
+        /* Release existing search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+        }
+
+        /* Open new search handle */
+        dirent_first (dirp);
+    }
+}
+
+/* Get first directory entry (internal) */
+static WIN32_FIND_DATAW*
+dirent_first(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *datap;
+
+    /* Open directory and retrieve the first entry */
+    dirp->handle = FindFirstFileW (dirp->patt, &dirp->data);
+    if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* a directory entry is now waiting in memory */
+        datap = &dirp->data;
+        dirp->cached = 1;
+
+    } else {
+
+        /* Failed to re-open directory: no directory entry in memory */
+        dirp->cached = 0;
+        datap = NULL;
+
+    }
+    return datap;
+}
+
+/* Get next directory entry (internal) */
+static WIN32_FIND_DATAW*
+dirent_next(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *p;
+
+    /* Get next directory entry */
+    if (dirp->cached != 0) {
+
+        /* A valid directory entry already in memory */
+        p = &dirp->data;
+        dirp->cached = 0;
+
+    } else if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* Get the next directory entry from stream */
+        if (FindNextFileW (dirp->handle, &dirp->data) != FALSE) {
+            /* Got a file */
+            p = &dirp->data;
+        } else {
+            /* The very last entry has been processed or an error occured */
+            FindClose (dirp->handle);
+            dirp->handle = INVALID_HANDLE_VALUE;
+            p = NULL;
+        }
+
+    } else {
+
+        /* End of directory stream reached */
+        p = NULL;
+
+    }
+
+    return p;
+}
+
+/* 
+ * Open directory stream using plain old C-string.
+ */
+static DIR*
+opendir(
+    const char *dirname) 
+{
+    struct DIR *dirp;
+    int error;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate memory for DIR structure */
+    dirp = (DIR*) malloc (sizeof (struct DIR));
+    if (dirp) {
+        wchar_t wname[PATH_MAX + 1];
+        size_t n;
+
+        /* Convert directory name to wide-character string */
+        error = dirent_mbstowcs_s(
+            &n, wname, PATH_MAX + 1, dirname, PATH_MAX);
+        if (!error) {
+
+            /* Open directory stream using wide-character name */
+            dirp->wdirp = _wopendir (wname);
+            if (dirp->wdirp) {
+                /* Directory stream opened */
+                error = 0;
+            } else {
+                /* Failed to open directory stream */
+                error = 1;
+            }
+
+        } else {
+            /* 
+             * Cannot convert file name to wide-character string.  This
+             * occurs if the string contains invalid multi-byte sequences or
+             * the output buffer is too small to contain the resulting
+             * string.
+             */
+            error = 1;
+        }
+
+    } else {
+        /* Cannot allocate DIR structure */
+        error = 1;
+    }
+
+    /* Clean up in case of error */
+    if (error  &&  dirp) {
+        free (dirp);
+        dirp = NULL;
+    }
+
+    return dirp;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * When working with text consoles, please note that file names returned by
+ * readdir() are represented in the default ANSI code page while any output to
+ * console is typically formatted on another code page.  Thus, non-ASCII
+ * characters in file names will not usually display correctly on console.  The
+ * problem can be fixed in two ways: (1) change the character set of console
+ * to 1252 using chcp utility and use Lucida Console font, or (2) use
+ * _cprintf function when writing to console.  The _cprinf() will re-encode
+ * ANSI strings to the console code page so many non-ASCII characters will
+ * display correcly.
+ */
+static struct dirent*
+readdir(
+    DIR *dirp) 
+{
+    WIN32_FIND_DATAW *datap;
+    struct dirent *entp;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp->wdirp);
+    if (datap) {
+        size_t n;
+        int error;
+
+        /* Attempt to convert file name to multi-byte string */
+        error = dirent_wcstombs_s(
+            &n, dirp->ent.d_name, MAX_PATH + 1, datap->cFileName, MAX_PATH);
+
+        /* 
+         * If the file name cannot be represented by a multi-byte string,
+         * then attempt to use old 8+3 file name.  This allows traditional
+         * Unix-code to access some file names despite of unicode
+         * characters, although file names may seem unfamiliar to the user.
+         *
+         * Be ware that the code below cannot come up with a short file
+         * name unless the file system provides one.  At least
+         * VirtualBox shared folders fail to do this.
+         */
+        if (error  &&  datap->cAlternateFileName[0] != '\0') {
+            error = dirent_wcstombs_s(
+                &n, dirp->ent.d_name, MAX_PATH + 1, datap->cAlternateFileName,
+                sizeof (datap->cAlternateFileName) / 
+                    sizeof (datap->cAlternateFileName[0]));
+        }
+
+        if (!error) {
+            DWORD attr;
+
+            /* Initialize directory entry for return */
+            entp = &dirp->ent;
+
+            /* Length of file name excluding zero terminator */
+            entp->d_namlen = n - 1;
+
+            /* File attributes */
+            attr = datap->dwFileAttributes;
+            if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+                entp->d_type = DT_CHR;
+            } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                entp->d_type = DT_DIR;
+            } else {
+                entp->d_type = DT_REG;
+            }
+
+            /* Reset dummy fields */
+            entp->d_ino = 0;
+            entp->d_reclen = sizeof (struct dirent);
+
+        } else {
+            /* 
+             * Cannot convert file name to multi-byte string so construct
+             * an errornous directory entry and return that.  Note that
+             * we cannot return NULL as that would stop the processing
+             * of directory entries completely.
+             */
+            entp = &dirp->ent;
+            entp->d_name[0] = '?';
+            entp->d_name[1] = '\0';
+            entp->d_namlen = 1;
+            entp->d_type = DT_UNKNOWN;
+            entp->d_ino = 0;
+            entp->d_reclen = 0;
+        }
+
+    } else {
+        /* No more directory entries */
+        entp = NULL;
+    }
+
+    return entp;
+}
+
+/*
+ * Close directory stream.
+ */
+static int
+closedir(
+    DIR *dirp) 
+{
+    int ok;
+    if (dirp) {
+
+        /* Close wide-character directory stream */
+        ok = _wclosedir (dirp->wdirp);
+        dirp->wdirp = NULL;
+
+        /* Release multi-byte character version */
+        free (dirp);
+
+    } else {
+
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream to beginning.
+ */
+static void
+rewinddir(
+    DIR* dirp) 
+{
+    /* Rewind wide-character string directory stream */
+    _wrewinddir (dirp->wdirp);
+}
+
+/* Convert multi-byte string to wide character string */
+static int
+dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = mbstowcs_s (pReturnValue, wcstr, sizeInWords, mbstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to wide-character string */
+    n = mbstowcs (wcstr, mbstr, count);
+    if (n < sizeInWords) {
+
+        /* Zero-terminate output buffer */
+        if (wcstr) {
+            wcstr[n] = 0;
+        }
+
+        /* Length of resuting multi-byte string WITH zero terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Could not convert string */
+        error = 1;
+
+    }
+
+#endif
+
+    return error;
+}
+
+/* Convert wide-character string to multi-byte string */
+static int
+dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes,
+    const wchar_t *wcstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = wcstombs_s (pReturnValue, mbstr, sizeInBytes, wcstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to multi-byte string */
+    n = wcstombs (mbstr, wcstr, count);
+    if (n < sizeInBytes) {
+
+        /* Zero-terminate output buffer */
+        if (mbstr) {
+            mbstr[n] = '\0';
+        }
+
+        /* Lenght of resulting multi-bytes string WITH zero-terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Cannot convert string */
+        error = 1;
+
+    }
+
+#endif
+
+    return error;
+}
+
+/* Set errno variable */
+static void
+dirent_set_errno(
+    int error)
+{
+#if defined(_MSC_VER)
+
+    /* Microsoft Visual Studio */
+    _set_errno (error);
+
+#else
+
+    /* Non-Microsoft compiler */
+    errno = error;
+
+#endif
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*DIRENT_H*/

--- a/win32/unistd.h
+++ b/win32/unistd.h
@@ -1,0 +1,19 @@
+/* stub unistd.h for use for MSVC compilers */
+#pragma once
+#ifndef UNISTD_H
+#define UNISTD_H
+
+#include <io.h>
+
+#ifdef _WIN64
+#define ssize_t __int64
+#else
+#define ssize_t long
+#endif
+
+#define R_OK    4       /* Test for read permission.  */
+#define W_OK    2       /* Test for write permission.  */
+#define X_OK    1       /* execute permission - unsupported in Windows, using it will crash */
+#define F_OK    0       /* Test for existence.  */
+
+#endif // UNISTD_H

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -1,0 +1,7 @@
+#pragma once
+#ifdef WIN32
+#define localtime_r(timep, result) localtime_s(result, timep)
+#define gmtime_r(timep, result) gmtime_s(result, timep)
+#define strncasecmp _strnicmp
+#define stat _stat
+#endif


### PR DESCRIPTION
This is a supporting PR for the one in SILE. Please refer to https://github.com/simoncozens/sile/pull/567 for an overview of the big picture.

Note:
1. `off_t` are changed into `off64_t` entirely, because Windows have a definition for `off_t` to 32-bit integer and it's hard to override.
2. Not sure why there is undefined `IS_KANJI` function in `dpxfile.c`. Looks like it's jumping one byte if its a Chinese character in the spawn argument. This is hacky so I commented it anyway. May need fix in the future for non-Latin support.