### PR TITLE
Add meson build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,3 +16,23 @@ jobs:
       - name: Make
         run: |
           make
+
+  build_meson:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Python Setup
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Setup packages
+        run: |
+          sudo apt-get install -y ninja-build
+          pip3 install meson
+      - name: Setup
+        run: |
+          meson setup .build
+      - name: Build
+        run: |
+          ninja dist -C .build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Setup
         run: |
           meson setup .build
-      - name: Build
+      - name: Dist Check
         run: |
           ninja dist -C .build
+      - name: Unit Tests
+        run: |
+          ninja test -C .build

--- a/config.h.meson
+++ b/config.h.meson
@@ -11,8 +11,3 @@
 #mesondefine HAVE_TIMEZONE
 #mesondefine HAVE_GETENV
 #mesondefine HAVE_MKSTEMP
-
-#ifdef _WIN32
-#define WIN32
-#endif
-

--- a/config.h.meson
+++ b/config.h.meson
@@ -1,13 +1,12 @@
 #mesondefine PACKAGE_VERSION
-#mesondefine HAVE_DLFCN_H
 #mesondefine HAVE_INTTYPES_H
 #mesondefine HAVE_STDINT_H
+#mesondefine HAVE_STDBOOL_H
 #mesondefine HAVE_STDLIB_H
 #mesondefine HAVE_STRING_H
 #mesondefine HAVE_SYS_STAT_H
 #mesondefine HAVE_SYS_TYPES_H
 #mesondefine HAVE_SYS_WAIT_H
-#mesondefine HAVE_UNISTD_H
 #mesondefine HAVE_TM_GMTOFF
 #mesondefine HAVE_TIMEZONE
 #mesondefine HAVE_GETENV

--- a/config.h.meson
+++ b/config.h.meson
@@ -1,0 +1,19 @@
+#mesondefine PACKAGE_VERSION
+#mesondefine HAVE_DLFCN_H
+#mesondefine HAVE_INTTYPES_H
+#mesondefine HAVE_STDINT_H
+#mesondefine HAVE_STDLIB_H
+#mesondefine HAVE_STRING_H
+#mesondefine HAVE_SYS_STAT_H
+#mesondefine HAVE_SYS_TYPES_H
+#mesondefine HAVE_SYS_WAIT_H
+#mesondefine HAVE_UNISTD_H
+#mesondefine HAVE_TM_GMTOFF
+#mesondefine HAVE_TIMEZONE
+#mesondefine HAVE_GETENV
+#mesondefine HAVE_MKSTEMP
+
+#ifdef _WIN32
+#define WIN32
+#endif
+

--- a/dpxfile.c
+++ b/dpxfile.c
@@ -27,7 +27,9 @@
 #if defined(WIN32)
 #include <windows.h>
 #include <wchar.h>
+#ifndef PATH_MAX
 #define PATH_MAX 2048 // do not use MAX_PATH as it's too small
+#endif
 #endif
 
 #include "libtexpdf.h"
@@ -48,7 +50,7 @@
 #define MAX_KEY_LEN 16
 
 #include <string.h>
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(WIN32) && defined(_MSC_VER)
 #include <io.h>
 #include <process.h>
 #include <wchar.h>
@@ -251,7 +253,7 @@ static int exec_spawn (char *cmd)
       }
     }
     *pp = '\0';
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(WIN32) && defined(_MSC_VER)
     if (strchr (buf, ' ') || strchr (buf, '\t')) {
       *qv = xcalloc (strlen(buf) + 3, sizeof (char));
       **qv = '\0';
@@ -425,7 +427,7 @@ dpx_create_temp_file (void)
   }
 #else /* use _tempnam or tmpnam */
   {
-#  if defined(WIN32) && !defined(__MINGW32__)
+#  if defined(WIN32) && defined(_MSC_VER)
     const char *_tmpd;
     char *p;
     _tmpd = dpx_get_tmpdir();
@@ -481,7 +483,7 @@ dpx_create_fix_temp_file (const char *filename)
       sprintf(s, "%02x", digest[i]);
       s += 2;
   }
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(WIN32) && defined(_MSC_VER)
   for (p = ret; *p; p++) {
     /*if (IS_KANJI (p))
       p++;

--- a/error.h
+++ b/error.h
@@ -23,8 +23,10 @@
 #ifndef _ERROR_H_
 #define _ERROR_H_
 
-#if defined(WIN32) 
-#  if defined(__MINGW32__)
+#if defined(WIN32)
+#  if defined(_MSC_VER)
+#    pragma warning(disable : 4101 4018)
+#  else
 #    define CDECL
 #  endif
 #  undef ERROR
@@ -34,7 +36,6 @@
 #  undef SETLINECAP
 #  undef SETLINEJOIN
 #  undef SETMITERLIMIT
-#  pragma warning(disable : 4101 4018)
 #else
 #  ifndef __cdecl
 #  define __cdecl

--- a/libtexpdf.h
+++ b/libtexpdf.h
@@ -41,14 +41,8 @@ extern int compat_mode;
 #define FOPEN_WBIN_MODE "wb"
 #endif /* not FOPEN_WBIN_MODE */
 
-#if defined(WIN32) && !defined(__MINGW32__)
-#define off64_t int64_t
-#define ftello _ftelli64
-#define fseeko _fseeki64
+#if defined(WIN32)
 #include "win32/win32.h"
-#elif defined(__MINGW32__)
-#define ftello ftello64
-#define fseeko fseeko64
 #endif
 
 #include "agl.h"

--- a/meson.build
+++ b/meson.build
@@ -172,6 +172,7 @@ install_headers(
     'unicode.h',
     'pkfont.h',
     'tfm.h',
+    subdir : 'libtexpdf'
 )
 
 libtexpdf_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -180,6 +180,8 @@ libtexpdf_dep = declare_dependency(
     link_with : libtexpdf,
 )
 
+subdir('tests')
+
 pkg.generate(libtexpdf,
     filebase : 'libtexpdf',
     name : 'libtexpdf',

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,188 @@
+project('libtexpdf', 'c', version : '2.4.6', default_options : ['c_std=gnu11'])
+
+pkg = import('pkgconfig')
+
+compiler = meson.get_compiler('c')
+
+conf = configuration_data()
+conf.set_quoted('PACKAGE_VERSION', meson.project_version())
+
+check_headers = ['dlfcn.h', 'inttypes.h', 'stdint.h', 'stdlib.h', 'string.h', 'sys/stat.h', 'sys/types.h', 'sys/wait.h', 'unistd.h']
+foreach header_name : check_headers
+    if compiler.has_header(header_name)
+        conf.set('HAVE_' + header_name.underscorify().to_upper(), 1)
+    endif
+endforeach
+
+if compiler.has_function('timezone', prefix : '#include <time.h>')
+    conf.set('HAVE_TIMEZONE', 1)
+endif
+
+if compiler.has_function('getenv', prefix : '#include <stdlib.h>')
+    conf.set('HAVE_GETENV', 1)
+endif
+
+if compiler.has_function('mkstemp', prefix : '#include <stdlib.h>')
+    conf.set('HAVE_MKSTEMP', 1)
+endif
+
+if compiler.has_member('struct tm', 'tm_gmtoff', prefix : '#include <time.h>')
+    conf.set('HAVE_TM_GMTOFF', 1)
+endif
+
+configure_file(input: 'config.h.meson', output: 'config.h', configuration: conf)
+
+libm = compiler.find_library('m', required : false)
+
+zlib_dep = dependency('zlib')
+libpng_dep = dependency('libpng')
+
+libtexpdf_deps = [libpng_dep, zlib_dep, libm]
+
+libtexpdf_cargs = ['-DXETEX', '-DBUILDING_LIBTEXPDF', '-DHAVE_CONFIG_H', '-DHAVE_ZLIB', '-DHAVE_ZLIB_COMPRESS2', '-DHAVE_LIBPNG']
+
+libtexpdf_sources = [
+	  'agl.c',
+	  'bmpimage.c',
+	  'cff.c',
+	  'cff_dict.c',
+	  'cid.c',
+	  'cidtype0.c',
+	  'cidtype2.c',
+	  'cmap.c',
+	  'cmap_read.c',
+	  'cmap_write.c',
+	  'cs_type2.c',
+	  'dpxcrypt.c',
+	  'dpxfile.c',
+	  'dpxutil.c',
+	  'epdf.c',
+	  'error.c',
+	  'fontmap.c',
+	  'jp2image.c',
+	  'jpegimage.c',
+	  'mem.c',
+	  'mfileio.c',
+	  'numbers.c',
+	  'otl_conf.c',
+	  'otl_opt.c',
+	  'pdfcolor.c',
+	  'pdfdev.c',
+	  'pdfdoc.c',
+	  'pdfdraw.c',
+	  'pdfencrypt.c',
+	  'pdfencoding.c',
+	  'pdffont.c',
+	  'pdfnames.c',
+	  'pdfobj.c',
+	  'pdfparse.c',
+	  'pdfresource.c',
+	  'pdfximage.c',
+	  'pngimage.c',
+	  'pst.c',
+	  'pst_obj.c',
+	  'sfnt.c',
+	  'subfont.c',
+	  't1_char.c',
+	  't1_load.c',
+	  'truetype.c',
+	  'tt_aux.c',
+	  'tt_cmap.c',
+	  'tt_glyf.c',
+	  'tt_gsub.c',
+	  'tt_post.c',
+	  'tt_table.c',
+	  'type0.c',
+	  'type1.c',
+	  'type1c.c',
+	  'unicode.c',
+	  'pkfont.c',
+	  'tfm.c',
+]
+
+libtexpdf = library('texpdf', libtexpdf_sources,
+    dependencies: libtexpdf_deps,
+    c_args: libtexpdf_cargs,
+    install: true,
+)
+
+install_headers(
+    'agl.h',
+    'bmpimage.h',
+    'cff.h',
+    'cff_dict.h',
+    'cff_limits.h',
+    'cff_stdstr.h',
+    'cff_types.h',
+    'cid_basefont.h',
+    'cid.h',
+    'cid_p.h',
+    'cidtype0.h',
+    'cidtype2.h',
+    'cmap.h',
+    'cmap_p.h',
+    'cmap_read.h',
+    'cmap_write.h',
+    'cs_type2.h',
+    'dpxcrypt.h',
+    'dpxfile.h',
+    'dpxutil.h',
+    'epdf.h',
+    'error.h',
+    'fontmap.h',
+    'jp2image.h',
+    'jpegimage.h',
+    'libtexpdf.h',
+    'mem.h',
+    'mfileio.h',
+    'numbers.h',
+    'otl_conf.h',
+    'otl_opt.h',
+    'pdfcolor.h',
+    'pdfdev.h',
+    'pdfdoc.h',
+    'pdfdraw.h',
+    'pdfencrypt.h',
+    'pdfencoding.h',
+    'pdffont.h',
+    'pdflimits.h',
+    'pdfnames.h',
+    'pdfobj.h',
+    'pdfparse.h',
+    'pdfresource.h',
+    'pdftypes.h',
+    'pdfximage.h',
+    'pngimage.h',
+    'pst.h',
+    'pst_obj.h',
+    'sfnt.h',
+    'subfont.h',
+    't1_char.h',
+    't1_load.h',
+    'truetype.h',
+    'tt_aux.h',
+    'tt_cmap.h',
+    'tt_glyf.h',
+    'tt_gsub.h',
+    'tt_post.h',
+    'tt_table.h',
+    'type0.h',
+    'type1.h',
+    'type1c.h',
+    'unicode.h',
+    'pkfont.h',
+    'tfm.h',
+)
+
+libtexpdf_dep = declare_dependency(
+    dependencies : libtexpdf_deps,
+    link_with : libtexpdf,
+)
+
+pkg.generate(libtexpdf,
+    filebase : 'libtexpdf',
+    name : 'libtexpdf',
+    description : 'A PDF library extracted from TeX\'s dvipdfmx',
+    url : 'https://github.com/sile-typesetter/libtexpdf',
+)
+

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,10 @@ libm = compiler.find_library('m', required : false)
 zlib_dep = dependency('zlib')
 libpng_dep = dependency('libpng')
 
+if not compiler.has_function('compress2', prefix : '#include <zlib.h>', dependencies: zlib_dep)
+	  error('zlib with compress2 is required')
+endif
+
 libtexpdf_deps = [libpng_dep, zlib_dep, libm]
 
 libtexpdf_cargs = ['-DXETEX', '-DBUILDING_LIBTEXPDF', '-DHAVE_CONFIG_H', '-DHAVE_ZLIB', '-DHAVE_ZLIB_COMPRESS2', '-DHAVE_LIBPNG']

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ compiler = meson.get_compiler('c')
 conf = configuration_data()
 conf.set_quoted('PACKAGE_VERSION', meson.project_version())
 
-check_headers = ['dlfcn.h', 'inttypes.h', 'stdint.h', 'stdlib.h', 'string.h', 'sys/stat.h', 'sys/types.h', 'sys/wait.h', 'unistd.h']
+check_headers = ['inttypes.h', 'stdint.h', 'stdbool.h', 'stdlib.h', 'string.h', 'sys/stat.h', 'sys/types.h', 'sys/wait.h']
 foreach header_name : check_headers
     if compiler.has_header(header_name)
         conf.set('HAVE_' + header_name.underscorify().to_upper(), 1)

--- a/meson.build
+++ b/meson.build
@@ -189,3 +189,5 @@ pkg.generate(libtexpdf,
     url : 'https://github.com/sile-typesetter/libtexpdf',
 )
 
+install_data('LICENSE', install_dir : 'share/libtexpdf')
+

--- a/pdfobj.c
+++ b/pdfobj.c
@@ -302,7 +302,7 @@ pdf_out_init (const char *filename, int do_encryption)
   output_stream = NULL;
 
   if (filename == NULL) { /* no filename: writing to stdout */
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(WIN32) && defined(_MSC_VER)
     setmode(fileno(stdout), _O_BINARY);
 #endif
     pdf_output_file = stdout;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,13 @@
 libtexpdf_include = include_directories('..')
 
+# FIXME:
+# Above we should not add libtexpdf_cargs but if they are not added
+# compiling may fail because the header inclusion is conditioned to
+# defines like HAVE_CONFIG_H and others.
+# In addition the header files tries to conditionally include config.h
+# but this latter is private and not exported.
 test_create = executable('test-create', 'test-create.c',
+    c_args: libtexpdf_cargs,
     dependencies: libtexpdf_dep,
     include_directories: libtexpdf_include,
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,8 @@
+libtexpdf_include = include_directories('..')
+
+test_create = executable('test-create', 'test-create.c',
+    dependencies: libtexpdf_dep,
+    include_directories: libtexpdf_include,
+)
+
+test('Create a PDF file', test_create, args : ['pdf-test.pdf'])

--- a/tests/test-create.c
+++ b/tests/test-create.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libtexpdf.h>
+
+double precision = 65536.0;
+char* producer = "SILE";
+
+pdf_doc *pdf_init (const char *fn, double w, double height) {
+  pdf_doc *p = texpdf_open_document(fn, 0, w, height, 0,0,0);
+  texpdf_init_device(p, 1 / precision, 2, 0);
+
+  pdf_rect mediabox;
+  mediabox.llx = 0.0;
+  mediabox.lly = 0.0;
+  mediabox.urx = w;
+  mediabox.ury = height;
+  texpdf_files_init();
+  texpdf_init_fontmaps();
+  texpdf_tt_aux_set_always_embed();
+  texpdf_doc_set_mediabox(p, 0, &mediabox);
+  texpdf_add_dict(p->info,
+               texpdf_new_name("Producer"),
+               texpdf_new_string(producer, strlen(producer)));
+  return p;
+}
+
+int pdf_finish(pdf_doc *p) {
+  texpdf_files_close();
+  texpdf_close_device();
+  texpdf_close_document(p);
+  texpdf_close_fontmaps();
+  return 0;
+}
+
+int pdf_add_content(pdf_doc *p, const char *input) {
+  int input_l = strlen(input);
+  texpdf_graphics_mode(p); /* Don't be mid-string! */
+  texpdf_doc_add_page_content(p, " ", 1);
+  texpdf_doc_add_page_content(p, input, input_l);
+  texpdf_doc_add_page_content(p, " ", 1);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    fprintf(stderr, "usage: %s <output-file>\n", argv[0]);
+    return 1;
+  }
+  const char *filename = argv[1];
+  const double width = 400.0, height = 600.0;
+  pdf_doc *p = pdf_init(filename, width, height);
+  texpdf_doc_begin_page(p, 1, 0, height);
+  pdf_add_content(p, "Hello world!");
+  texpdf_doc_end_page(p);
+  pdf_finish(p);
+  return 0;
+}

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -1,7 +1,10 @@
 #pragma once
-#ifdef WIN32
 #define localtime_r(timep, result) localtime_s(result, timep)
 #define gmtime_r(timep, result) gmtime_s(result, timep)
 #define strncasecmp _strnicmp
+#if defined(_MSC_VER)
+#define off64_t int64_t
+#define ftello _ftelli64
+#define fseeko _fseeki64
 #define stat _stat
 #endif


### PR DESCRIPTION
Hi,

I've created a pull request that adds a Meson build configuration to the project. Meson is a modern build system that is used by high-profile open source projects such as GNOME, GTK, and Mesa3D. It is significantly simpler to use and maintain than autotools, and it has the added benefit of being cross-platform, working on macOS and Windows using MinGW. This configuration also includes a pkg-config file. I believe it would be beneficial to have an alternative build system available.

I understand that adding a new build system may require additional maintenance, and I'm happy to help with any questions or issues that may arise. Let me know if there's anything else I can do to assist with the review and merging of this pull request.

Thank you for considering this contribution.